### PR TITLE
메모장 CRUD 기능 구현

### DIFF
--- a/src/main/java/springstudy/memorest/controller/MemoController.java
+++ b/src/main/java/springstudy/memorest/controller/MemoController.java
@@ -1,0 +1,44 @@
+package springstudy.memorest.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+import springstudy.memorest.domain.Memo;
+import springstudy.memorest.domain.MemoForm;
+import springstudy.memorest.domain.Response;
+import springstudy.memorest.service.MemoService;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/memo")
+public class MemoController {
+    @Autowired
+    private MemoService memoService;
+    @PostMapping("/create")
+    public Response createMemo(@RequestBody MemoForm memoForm) {
+        memoService.createMemo(memoForm);
+        return new Response(200, "OK");
+    }
+
+    @GetMapping("/{id}")
+    public Memo getMemoContent(@PathVariable Long id) {
+        return memoService.getMemoContent(id);
+    }
+
+    @GetMapping("/list")
+    public List<Memo> getMemoList() {
+        return memoService.getMemoList();
+    }
+
+    @PostMapping(value = "/update/{id}")
+    public Response updateMemo(@PathVariable Long id, @RequestBody MemoForm memoForm) {
+        memoService.updateMemo(id, memoForm);
+        return new Response(200, "OK");
+    }
+
+    @DeleteMapping(value = "/delete/{id}")
+    public Response deleteMemo(@PathVariable Long id) {
+        memoService.deleteMemo(id);
+        return new Response(200, "OK");
+    }
+}

--- a/src/main/java/springstudy/memorest/domain/Memo.java
+++ b/src/main/java/springstudy/memorest/domain/Memo.java
@@ -1,0 +1,25 @@
+package springstudy.memorest.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter @Setter
+public class Memo {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    private String content;
+
+    private String author;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime created;
+}

--- a/src/main/java/springstudy/memorest/domain/MemoForm.java
+++ b/src/main/java/springstudy/memorest/domain/MemoForm.java
@@ -1,0 +1,20 @@
+package springstudy.memorest.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class MemoForm {
+    private String title;
+    private String content;
+    private String author;
+
+    @Override
+    public String toString() {
+        return "MemoForm{" +
+                "title='" + title + '\'' +
+                ", content='" + content + '\'' +
+                ", author='" + author + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/springstudy/memorest/domain/Response.java
+++ b/src/main/java/springstudy/memorest/domain/Response.java
@@ -1,0 +1,3 @@
+package springstudy.memorest.domain;
+
+public record Response(int statusCode, String message) { }

--- a/src/main/java/springstudy/memorest/repository/MemoRepository.java
+++ b/src/main/java/springstudy/memorest/repository/MemoRepository.java
@@ -1,0 +1,7 @@
+package springstudy.memorest.repository;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import springstudy.memorest.domain.Memo;
+
+public interface MemoRepository extends JpaRepository<Memo, Long> { }

--- a/src/main/java/springstudy/memorest/service/MemoService.java
+++ b/src/main/java/springstudy/memorest/service/MemoService.java
@@ -1,0 +1,46 @@
+package springstudy.memorest.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import springstudy.memorest.domain.Memo;
+import springstudy.memorest.domain.MemoForm;
+import springstudy.memorest.repository.MemoRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@Transactional
+public class MemoService {
+    @Autowired
+    private MemoRepository memoRepository;
+
+    public void createMemo(MemoForm memoForm) {
+        Memo memo = new Memo();
+        memo.setAuthor(memoForm.getAuthor());
+        memo.setTitle(memoForm.getTitle());
+        memo.setContent(memoForm.getContent());
+        memo.setCreated(LocalDateTime.now());
+        memoRepository.save(memo);
+    }
+
+    public Memo getMemoContent(Long id) {
+        return memoRepository.findById(id).get();
+    }
+
+    public List<Memo> getMemoList() {
+        return memoRepository.findAll();
+    }
+
+    public void updateMemo(Long id, MemoForm memoForm) {
+        Memo memo = memoRepository.findById(id).get();
+        memo.setContent(memoForm.getContent());
+        memo.setTitle(memoForm.getTitle());
+        memo.setAuthor(memoForm.getAuthor());
+    }
+
+    public void deleteMemo(Long id) {
+        memoRepository.deleteById(id);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+spring:
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/memo-rest
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.hibernate.orm.jdbc.bind: trace


### PR DESCRIPTION
## 완료한 기능 명세
- [x] #3 
- [x] #4 
- [x] #5 
- [x] #6 
- [x] #7 

## 고민과 해결 과정

![image](https://github.com/sickbirdd/memo-rest/assets/39708676/5d4f81f0-f4db-4331-acea-00796787ed10)

![image](https://github.com/sickbirdd/memo-rest/assets/39708676/a8d336b5-ea89-47c1-9802-04eb356120a0)

HTTP Request를 보냈을 때 MemoService를 제대로 불러오지 못하는 현상이 발생했다. **생성자 주입** 방식에서 생성자가 하나인 경우에는 `Autowired`를 생략할 수 있다. 따라서 처음에는 잘못된 부분이 없는 줄 알아서 많이 당황했다.
하지만 코드를 다시 한 번 확인해 본 결과, 위 코드에서 사용하고 있는 방법은 **생성자 주입** 방식이 아닌 **필드 주입** 방식이다. 따라서, 꼭 `Autowired`를 써줘야 했고, `Autowired`를 추가해서 해결할 수 있었다.

만약에 **생성자 주입** 방식으로 바꾸고 싶다면 직접 생성자를 정의해서 사용하거나, Lombok의 `RequiredArgsConstructor`를 사용해서 바꾸면 된다!
